### PR TITLE
Update bp-xprofile-custom-fields-type.php

### DIFF
--- a/bp-xprofile-custom-fields-type.php
+++ b/bp-xprofile-custom-fields-type.php
@@ -1035,7 +1035,7 @@ function bxcft_xprofile_get_hidden_fields_for_user($hidden_fields, $displayed_us
     
     return $hidden_fields;
 }
-add_filter('bp_xprofile_get_hidden_fields_for_user', 'bxcft_xprofile_get_hidden_fields_for_user', 3);
+add_filter('bp_xprofile_get_hidden_fields_for_user', 'bxcft_xprofile_get_hidden_fields_for_user', 1, 3);
 
 /**
  * Update profile 


### PR DESCRIPTION
Bug in setting up add_filter.

It requires a priority parameter first before the accepted_args so it only send the hidden fields.  The other 2 fields $display_user_id and $current_user_id is set to 0 and the function returns erratic or no results because of that.
